### PR TITLE
Dias festivos y dominicales bloqueados

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.49.8",
         "@tailwindcss/vite": "^4.1.4",
         "axios": "^1.9.0",
+        "date-holidays": "^3.25.2",
         "dayjs": "^1.11.13",
         "file-saver": "^2.0.5",
         "framer-motion": "^12.10.5",
@@ -1845,8 +1846,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/astronomia": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-4.2.0.tgz",
+      "integrity": "sha512-mTvpBGyXB80aSsDhAAiuwza5VqAyqmj5yzhjBrFhRy17DcWDzJrb8Vdl4Sm+g276S+mY7bk/5hi6akZ5RQFeHg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1983,6 +1991,17 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/caldate": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/caldate/-/caldate-2.0.5.tgz",
+      "integrity": "sha512-JndhrUuDuE975KUhFqJaVR1OQkCHZqpOrJur/CFXEIEhWhBMjxO85cRSK8q4FW+B+yyPq6GYua2u4KvNzTcq0w==",
+      "dependencies": {
+        "moment-timezone": "^0.5.43"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2221,6 +2240,68 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/date-bengali-revised": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-2.0.2.tgz",
+      "integrity": "sha512-q9iDru4+TSA9k4zfm0CFHJj6nBsxP7AYgWC/qodK/i7oOIlj5K2z5IcQDtESfs/Qwqt/xJYaP86tkazd/vRptg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-chinese": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-2.1.4.tgz",
+      "integrity": "sha512-WY+6+Qw92ZGWFvGtStmNQHEYpNa87b8IAQ5T8VKt4wqrn24lBXyyBnWI5jAIyy7h/KVwJZ06bD8l/b7yss82Ww==",
+      "dependencies": {
+        "astronomia": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-easter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.3.tgz",
+      "integrity": "sha512-aOViyIgpM4W0OWUiLqivznwTtuMlD/rdUWhc5IatYnplhPiWrLv75cnifaKYhmQwUBLAMWLNG4/9mlLIbXoGBQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.25.2.tgz",
+      "integrity": "sha512-xtgGWIBn5tGTA6QdYxKKVH1nogrY0SSbluDRDeUqnAvJy5fKMNjlrsAwmnzypjzF+TcdPvMd9KYfXs3KinQ2BA==",
+      "dependencies": {
+        "date-holidays-parser": "^3.4.7",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "prepin": "^1.0.3"
+      },
+      "bin": {
+        "holidays2json": "scripts/holidays2json.cjs"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays-parser": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-3.4.7.tgz",
+      "integrity": "sha512-h09ZEtM6u5cYM6m1bX+1Ny9f+nLO9KVZUKNPEnH7lhbXYTfqZogaGTnhONswGeIJFF91UImIftS3CdM9HLW5oQ==",
+      "dependencies": {
+        "astronomia": "^4.1.1",
+        "caldate": "^2.0.5",
+        "date-bengali-revised": "^2.0.2",
+        "date-chinese": "^2.1.4",
+        "date-easter": "^1.0.3",
+        "deepmerge": "^4.3.1",
+        "jalaali-js": "^1.2.7",
+        "moment-timezone": "^0.5.47"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -2250,6 +2331,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3016,6 +3105,11 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jalaali-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.2.8.tgz",
+      "integrity": "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A=="
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -3036,7 +3130,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3387,6 +3480,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3451,6 +3549,25 @@
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dependencies": {
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -3655,6 +3772,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prepin/-/prepin-1.0.3.tgz",
+      "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA==",
+      "bin": {
+        "prepin": "bin/prepin.js"
       }
     },
     "node_modules/proxy-from-env": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.49.8",
     "@tailwindcss/vite": "^4.1.4",
     "axios": "^1.9.0",
+    "date-holidays": "^3.25.2",
     "dayjs": "^1.11.13",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.10.5",

--- a/frontend/src/components/dashboard/MonthCalendarView.jsx
+++ b/frontend/src/components/dashboard/MonthCalendarView.jsx
@@ -1,23 +1,9 @@
 import React from "react";
-import { dateUtils } from "../../utils/dateUtils";
+import { dateUtils, isDayBlocked, canClickDay } from "../../utils/dateUtils.js";
+import { isSunday, getHolidayInfo } from "../../utils/holidayUtils.js";
 import dayjs from "dayjs";
 
 const MonthCalendarView = ({ year, month, onDaySelect }) => {
-  const monthNames = [
-    "Enero",
-    "Febrero",
-    "Marzo",
-    "Abril",
-    "Mayo",
-    "Junio",
-    "Julio",
-    "Agosto",
-    "Septiembre",
-    "Octubre",
-    "Noviembre",
-    "Diciembre",
-  ];
-
   const dayNames = [
     "Domingo",
     "Lunes",
@@ -83,6 +69,20 @@ const MonthCalendarView = ({ year, month, onDaySelect }) => {
   const days = generateCalendarDays();
   const today = dayjs().toDate();
 
+  const handleDayClick = (dayObj) => {
+    if (!canClickDay(dayObj.date, dayObj.isCurrentMonth)) {
+      return;
+    }
+
+    if (onDaySelect) {
+      onDaySelect(
+        dayObj.date.getFullYear(),
+        dayObj.date.getMonth(),
+        dayObj.date.getDate()
+      );
+    }
+  };
+
   return (
     <div className="overflow-hidden rounded-xl border border-gray-600">
       {/* Días de la semana */}
@@ -100,7 +100,9 @@ const MonthCalendarView = ({ year, month, onDaySelect }) => {
       {/* Días del mes */}
       <div className="grid grid-cols-7">
         {days.map((dayObj, index) => {
-          const isToday = dayjs(dayObj.date).isSame(dayjs(), "day");
+          const isToday = dayjs(dayObj.date).isSame(today, "day");
+          const blocked = isDayBlocked(dayObj.date);
+          const holidayInfo = getHolidayInfo(dayObj.date);
 
           return (
             <div
@@ -108,19 +110,19 @@ const MonthCalendarView = ({ year, month, onDaySelect }) => {
               className={`
                 min-h-32 p-3 border-r border-b border-gray-600 last:border-r-0
                 ${dayObj.isCurrentMonth ? "bg-[#1a1a26]" : "bg-[#232336]"}
-                hover:bg-[#2a2a40] transition-colors cursor-pointer
-              `}
-              onClick={() => {
-                if (dayObj.isCurrentMonth && onDaySelect) {
-                  onDaySelect(
-                    dayObj.date.getFullYear(),
-                    dayObj.date.getMonth(),
-                    dayObj.date.getDate()
-                  );
+                ${
+                  dayObj.isCurrentMonth && !blocked
+                    ? "hover:bg-[#2a2a40] cursor-pointer"
+                    : blocked && dayObj.isCurrentMonth
+                    ? "cursor-not-allowed opacity-60"
+                    : "cursor-not-allowed"
                 }
-              }}
+                transition-colors
+              `}
+              onClick={() => handleDayClick(dayObj)}
             >
-              <div className="h-full flex flex-col">
+              <div className="h-full flex flex-col relative">
+                {/* Número del día */}
                 <div
                   className={`
                     text-sm font-medium mb-2
@@ -128,6 +130,8 @@ const MonthCalendarView = ({ year, month, onDaySelect }) => {
                       dayObj.isCurrentMonth
                         ? isToday
                           ? "text-purple-400 font-bold"
+                          : blocked
+                          ? "text-gray-500"
                           : "text-white"
                         : "text-gray-500"
                     }
@@ -136,19 +140,45 @@ const MonthCalendarView = ({ year, month, onDaySelect }) => {
                   {dayObj.day}
                 </div>
 
+                {/* Indicadores para días bloqueados */}
+                {blocked && dayObj.isCurrentMonth && (
+                  <div className="absolute top-1 right-1">
+                    {isSunday(dayObj.date) ? (
+                      <span className="text-xs" title="Domingo">
+                        😴😴😴😴😴
+                      </span>
+                    ) : holidayInfo ? (
+                      <span className="text-xs" title={holidayInfo.name}>
+                        🥳🥳🥳🥳
+                      </span>
+                    ) : null}
+                  </div>
+                )}
+
                 <div className="flex-1 space-y-1">
-                  {/* Ejemplo de un pc por reparar xd */}
-                  {dayObj.isCurrentMonth && dayObj.day === 16 && (
-                    <div className="bg-purple-600/80 text-white text-xs px-2 py-1 rounded">
-                      Limpieza teclado de PC
-                    </div>
-                  )}
-                  {dayObj.isCurrentMonth && dayObj.day === 25 && (
-                    <div className="bg-blue-600/80 text-white text-xs px-2 py-1 rounded">
-                      Entrega del pc de Juan
-                    </div>
+                  {/* Solo mostrar contenido si no está bloqueado */}
+                  {dayObj.isCurrentMonth && !blocked && (
+                    <>
+                      {/* Ejemplo de tareas */}
+                      {dayObj.day === 16 && (
+                        <div className="bg-purple-600/80 text-white text-xs px-2 py-1 rounded">
+                          Limpieza teclado de PC
+                        </div>
+                      )}
+                      {dayObj.day === 25 && (
+                        <div className="bg-blue-600/80 text-white text-xs px-2 py-1 rounded">
+                          Entrega del pc de Juan
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
+
+                {holidayInfo && dayObj.isCurrentMonth && (
+                  <div className="absolute bottom-0 left-0 right-0 text-xs text-center text-gray-600 bg-yellow-100/90 rounded-b px-1 py-1">
+                    {holidayInfo.name}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/frontend/src/components/home/navbar.jsx
+++ b/frontend/src/components/home/navbar.jsx
@@ -18,14 +18,9 @@ const Navbar = () => {
           <Link to="/" className="hover:text-gray-300">
             Inicio
           </Link>
-          <a
-            href="/sobre-nosotros"
-            className="hover:text-gray-300"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Sobre Nosotros
-          </a>
+          <Link to="/sobre-nosotros" className="hover:text-gray-300">
+            Sobre Nosotros    
+          </Link>
         </div>
 
         {/* Botones a la derecha */}

--- a/frontend/src/components/legal/AboutUsSection.jsx
+++ b/frontend/src/components/legal/AboutUsSection.jsx
@@ -8,7 +8,7 @@ const AboutUsSection = () => (
           <span className="text-gray-500 text-lg">Plantilla para imagen :3</span>
         </div>
       </div>
-      <div className="w-full md:w-1/2 text-left text-white mt-30">
+      <div className="w-full md:w-1/2 text-left text-white mt-20">
         <h2 className="font-['Figtree'] text-4xl md:text-6xl lg:text-8xl font-bold mb-3 text-white">
           Quienes Somos
         </h2>

--- a/frontend/src/components/legal/CorporateValuesSection.jsx
+++ b/frontend/src/components/legal/CorporateValuesSection.jsx
@@ -10,27 +10,31 @@ const values = [
 ];
 
 const CorporateValuesSection = () => (
-  <section className="relative py-16 px-6 lg:px-16 md:py-24 overflow-hidden">
+  <section className="relative min-h-screen flex items-center justify-center py-12 md:py-16 lg:py-20 px-4 md:px-8 lg:px-16 overflow-hidden">
     {/* Patrón de fondo sutil */}
-    <div className="absolute inset-0 z-0 bg-repeat bg-[size:100px_100px] opacity-10" style={{ backgroundImage: `linear-gradient(135deg, #4A148C 25%, transparent 25%), linear-gradient(-45deg, #4A148C 25%, transparent 25%), linear-gradient(45deg, #4A148C 25%, transparent 25%), linear-gradient(-135deg, #4A148C 25%, #111827 25%)` }}></div>
+    <div className="absolute inset-0 z-0 bg-repeat bg-[size:100px_100px] opacity-10" ></div>
     
-    <div className="relative z-10 container mx-auto flex flex-col items-center text-white">
-      <h2 className="font-['Figtree'] text-4xl md:text-6xl lg:text-8xl font-bold mb-10 text-white text-center">
+    <div className="relative z-10 container mx-auto flex flex-col items-center text-white max-w-7xl">
+      <h2 className="font-['Figtree'] text-3xl md:text-5xl lg:text-6xl xl:text-7xl font-bold mb-6 md:mb-8 lg:mb-10 text-white text-center">
         Valores Corporativos
       </h2>
-        <h3 className="font-['Figtree'] text-base md:text-3xl lg:text-4xl text-purple-300 mb-4">
-            Principios que guían nuestro camino
-        </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-30 p-20 w-full">
-        
+      <h3 className="font-['Figtree'] text-lg md:text-2xl lg:text-3xl xl:text-4xl text-purple-300 mb-8 md:mb-12 lg:mb-16 text-center">
+        Principios que guían nuestro camino
+      </h3>
+      
+      {/* Grid responsivo con tarjetas cuadradas */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 lg:gap-10 w-full max-w-6xl">
         {values.map((value) => (
           <div
             key={value.name}
-            className="bg-gradient-to-br from-purple-900/60 to-gray-900/80 rounded-2xl p-20 shadow-lg border border-purple-700/40 hover:scale-105 transition-transform 
-                       flex flex-col justify-center items-center text-center aspect-square"
+            className="bg-gradient-to-br from-purple-900/60 to-gray-900/80 rounded-2xl p-6 md:p-8 lg:p-10 shadow-lg border border-purple-700/40 hover:scale-105 transition-transform duration-300 flex flex-col justify-center items-center text-center aspect-square"
           >
-            <h3 className="font-bold text-purple-300 text-3xl md:text-4xl mb-2">{value.name}</h3>
-            <p className="text-gray-200 text-base md:text-lg mt-4">{value.description}</p>
+            <h3 className="font-bold text-purple-300 text-xl md:text-2xl lg:text-3xl mb-3 md:mb-4">
+              {value.name}
+            </h3>
+            <p className="text-gray-200 text-sm md:text-base lg:text-lg leading-relaxed">
+              {value.description}
+            </p>
           </div>
         ))}
       </div>

--- a/frontend/src/components/legal/LegalPage.jsx
+++ b/frontend/src/components/legal/LegalPage.jsx
@@ -1,8 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import logoComplete from "../../../public/img/logoCompleteWhite.svg";
-import LogoTransparente from "../../assets/LogoTransparente.png";
-import Footer from "../../components/home/footer";
+import Navbar from "../home/navbar";  // Importar correctamente como componente
 import AboutUsSection from "./AboutUsSection";
 import MissionVisionSection from "./MissionVisionSection";
 import CorporateValuesSection from "./CorporateValuesSection";
@@ -13,30 +10,19 @@ const LegalPage = () => (
   <div className="bg-black text-white relative overflow-hidden">
     {/* Fondo general que se desplaza y pulsa suavemente */}
     <div className="fixed inset-0 z-0 pointer-events-none">
-
       <div className="absolute top-1/2 left-1/4 w-[50rem] h-[50rem] rounded-full bg-purple-900/30 blur-3xl transform -translate-x-1/2 -translate-y-1/2 animate-pulse-slow"></div>
       <div className="absolute bottom-1/4 right-1/4 w-[40rem] h-[40rem] rounded-full bg-fuchsia-800/30 blur-3xl transform translate-x-1/2 translate-y-1/2 animate-pulse-slow delay-1000"></div>
-      </div>
+    </div>
     
     <div className="relative z-10">
-      <header className="w-full flex justify-between items-center py-6 px-4 md:px-16 lg:px-20 bg-black/60 backdrop-blur-sm text-white sticky top-0 z-50">
-        <div className="flex items-center gap-2">
-            <img src={LogoTransparente} alt="Logo Atlas" className="h-10 w-auto" />
-            <img src={logoComplete} alt="Atlas Soft" className="h-8 w-auto hidden md:block" />
-        </div>
-        <div>
-          <Link to="/" className="text-white hover:text-purple-300 transition-colors text-lg font-bold">
-            Volver a Inicio
-          </Link>
-        </div>
-      </header>
-
-      <AboutUsSection />
-      <MissionVisionSection />
-      <CorporateValuesSection />
-      <ServicesSection />
-      <ContactsSection />
-      <Footer />
+      <Navbar />  {/* Usar como componente React con mayúscula */}
+      <div>
+        <AboutUsSection />
+        <MissionVisionSection />
+        <CorporateValuesSection />
+        <ServicesSection />
+        <ContactsSection />
+      </div>
     </div>
   </div>
 );

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,19 +1,20 @@
 import dayjs from "dayjs";
+import { isBlockedDay } from "./holidayUtils.js";
 
 export const dateUtils = {
-  // días del mes
+  // se obtienen los días del mes
   getDaysInMonth: (year, month) => dayjs(`${year}-${month + 1}`).daysInMonth(),
 
-  // primer día del mes
+  // Esto es para el primer día de cada mes
   getFirstDayOfMonth: (year, month) => dayjs(`${year}-${month + 1}-01`).day(),
 
-  // Verificar si es hoy
+  // Compara la fecha si es hoy
   isToday: (date) => dayjs(date).isSame(dayjs(), "day"),
 
   // Obtener fecha actual
   today: () => dayjs().toDate(),
 
-  // reiniciar fechas
+  // Reinicio total de las fechas (por si acaso xd)
   format: (date, format = "YYYY-MM-DD") => dayjs(date).format(format),
 
   // Navegar entre fechas
@@ -22,7 +23,7 @@ export const dateUtils = {
   addYear: (date) => dayjs(date).add(1, "year").toDate(),
   subtractYear: (date) => dayjs(date).subtract(1, "year").toDate(),
 
-  // Obtener fecha de hoy en formato string
+  // Obtener fecha de hoy en formato string (textpo)
   getToday: () => dayjs().format("YYYY-MM-DD"),
 
   // Crear fecha desde string
@@ -32,3 +33,13 @@ export const dateUtils = {
   getCurrentYear: () => dayjs().year(),
   getCurrentMonth: () => dayjs().month(),
 };
+
+
+export function isDayBlocked(date) {
+  return isBlockedDay(date);
+}
+
+// prueba si se puede clicar el día
+export function canClickDay(date, isCurrentMonth = true) {
+  return isCurrentMonth && !isDayBlocked(date);
+}

--- a/frontend/src/utils/holidayUtils.js
+++ b/frontend/src/utils/holidayUtils.js
@@ -1,0 +1,38 @@
+import Holidays from "date-holidays";
+
+// Estoes local, cambiar según necesidad (por ahora colombia)
+const hd = new Holidays("CO");
+
+export function isSunday(date) {//verifica si es domingo
+  return date.getDay() === 0;
+}
+
+//sirve pa verificar que es festivo con la libreria
+export function isHoliday(date) {
+  const holidays = hd.getHolidays(date.getFullYear());
+  return holidays.some((holiday) => {
+    const holidayDate = new Date(holiday.date);
+    return holidayDate.toDateString() === date.toDateString();
+  });
+}
+
+//verifica si ese dia no cumple las condiciones para asignar tareas (dominical o festivo)
+export function isBlockedDay(date) {
+  return isSunday(date) || isHoliday(date);
+}
+
+// con la libreria obtiene info del festivo (para colocarle los nombres en la interfaz)
+export function getHolidayInfo(date) {
+  const holidays = hd.getHolidays(date.getFullYear());
+  const holiday = holidays.find((holiday) => {
+    const holidayDate = new Date(holiday.date);
+    return holidayDate.toDateString() === date.toDateString();
+  });
+
+  return holiday
+    ? {
+        name: holiday.name,
+        type: holiday.type,
+      }
+    : null;
+}


### PR DESCRIPTION
## Summary by Sourcery

Add support for blocking Sundays and holidays in the month calendar and refine layout and navigation components across the app.

New Features:
- Disable clicking on Sundays and holidays in the MonthCalendarView and visually mark them with emoji indicators and holiday names

Enhancements:
- Introduce holidayUtils module using date-holidays to detect holidays and expose isDayBlocked and getHolidayInfo helpers
- Add canClickDay helper to dateUtils for clickability checks
- Refactor LegalPage to use a reusable Navbar component and restructure its sections
- Convert the “Sobre Nosotros” navbar item to a React Router Link
- Revise CorporateValuesSection and AboutUsSection with improved spacing, responsive grids, and updated card and typography styles

Build:
- Add date-holidays dependency for holiday detection