### PR TITLE
Fix bug side bar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import HomePage from "./pages/Home/homepage";
+import AboutUsPage from "./pages/Home/AboutUsPage";
 
 // Autenticación
 import Login from "./pages/Auth/Login";
@@ -42,6 +43,7 @@ const App = () => {
 
         <Route path="/" element={<Navigate to="/home" />} />
         <Route path="/home" element={<HomePage />} />
+        <Route path="/quienes-somos" element={<AboutUsPage />} />
         <Route path="/iniciar-sesion" element={<Login />} />
         <Route path="/registrarse" element={<Register />} />
         <Route path="/recuperar-contrasena" element={<PasswordRecovery />} />

--- a/frontend/src/components/home/navbar.jsx
+++ b/frontend/src/components/home/navbar.jsx
@@ -32,7 +32,7 @@ const Navbar = () => {
           <Link to="/" className="hover:text-gray-300 whitespace-nowrap">
             Inicio
           </Link>
-          <Link to="/sobre-nosotros" className="hover:text-gray-300 whitespace-nowrap">
+          <Link to="/quienes-somos" className="hover:text-gray-300 whitespace-nowrap">
             Sobre Nosotros    
           </Link>
         </div>

--- a/frontend/src/components/legal/LegalPage.jsx
+++ b/frontend/src/components/legal/LegalPage.jsx
@@ -1,30 +1,41 @@
 import React from "react";
-import Navbar from "../home/navbar";  
-import AboutUsSection from "./AboutUsSection";
-import MissionVisionSection from "./MissionVisionSection";
-import CorporateValuesSection from "./CorporateValuesSection";
-import ServicesSection from "./ServicesSection";
-import ContactsSection from "./ContactsSection";
+import { useNavigate, useLocation } from "react-router-dom";
 
-const LegalPage = () => (
-  <div className="bg-black text-white relative overflow-hidden">
-    {/* Fondo general que se desplaza y pulsa suavemente */}
-    <div className="fixed inset-0 z-0 pointer-events-none">
-      <div className="absolute top-1/2 left-1/4 w-[50rem] h-[50rem] rounded-full bg-purple-900/30 blur-3xl transform -translate-x-1/2 -translate-y-1/2 animate-pulse-slow"></div>
-      <div className="absolute bottom-1/4 right-1/4 w-[40rem] h-[40rem] rounded-full bg-fuchsia-800/30 blur-3xl transform translate-x-1/2 translate-y-1/2 animate-pulse-slow delay-1000"></div>
-    </div>
-    
-    <div className="relative z-10">
-      <Navbar /> 
-      <div>
-        <AboutUsSection />
-        <MissionVisionSection />
-        <CorporateValuesSection />
-        <ServicesSection />
-        <ContactsSection />
+const LegalPage = ({ title, content }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleBack = () => {
+    if (location.state && location.state.from) {
+      navigate(location.state.from);
+    } else {
+      navigate(-1);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-black text-white relative">
+      <div
+        className="absolute inset-0"
+        style={{
+          background: "radial-gradient(circle at 50% 80%, rgba(107, 70, 193, 0.3), rgba(0, 0, 0, 0.9) 90%)",
+        }}
+      ></div>
+      <div className="relative z-10 bg-[#1E1B2E] p-8 rounded-2xl shadow-2xl w-full max-w-3xl border border-gray-700">
+        <h1 className="text-3xl font-bold mb-6 text-center">{title}</h1>
+        <div className="text-gray-300 space-y-4">{content}</div>
+        <div className="mt-6 text-center">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="text-purple-500 hover:underline bg-transparent border-none cursor-pointer"
+          >
+            Regresar
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default LegalPage;

--- a/frontend/src/pages/Home/AboutUsPage.jsx
+++ b/frontend/src/pages/Home/AboutUsPage.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Navbar from "../../components/home/navbar";  
+import AboutUsSection from "../../components/legal/AboutUsSection";
+import MissionVisionSection from "../../components/legal/MissionVisionSection";
+import CorporateValuesSection from "../../components/legal/CorporateValuesSection";
+import ServicesSection from "../../components/legal/ServicesSection";
+import ContactsSection from "../../components/legal/ContactsSection";
+
+const AboutUsPage = () => (
+    <div className="bg-black text-white relative overflow-hidden">
+    {/* Fondo general que se desplaza y pulsa suavemente */}
+    <div className="fixed inset-0 z-0 pointer-events-none">
+        <div className="absolute top-1/2 left-1/4 w-[50rem] h-[50rem] rounded-full bg-purple-900/30 blur-3xl transform -translate-x-1/2 -translate-y-1/2 animate-pulse-slow"></div>
+        <div className="absolute bottom-1/4 right-1/4 w-[40rem] h-[40rem] rounded-full bg-fuchsia-800/30 blur-3xl transform translate-x-1/2 translate-y-1/2 animate-pulse-slow delay-1000"></div>
+    </div>
+    
+    <div className="relative z-10">
+        <Navbar /> 
+        <div>
+        <AboutUsSection />
+        <MissionVisionSection />
+        <CorporateValuesSection />
+        <ServicesSection />
+        <ContactsSection />
+        </div>
+    </div>
+    </div>
+);
+
+export default AboutUsPage;


### PR DESCRIPTION
Changed de route of About us page, now on the side bar in footer, links directs to legal components

## Summary by Sourcery

Fix the sidebar navigation link for the About Us page, introduce a dedicated AboutUsPage, and refactor the LegalPage into a generic component with dynamic title, content, and back navigation.

Bug Fixes:
- Correct the sidebar link path from /sobre-nosotros to /quienes-somos
- Ensure the back button on legal pages navigates to the previous route

Enhancements:
- Refactor LegalPage to accept dynamic title and content props and include a styled back button
- Add a new AboutUsPage component that renders company information sections
- Register the /quienes-somos route in App.jsx pointing to AboutUsPage