### PR TITLE
Fix the bug of specialchar on register

### DIFF
--- a/frontend/src/components/functionalities/passwordValidation.jsx
+++ b/frontend/src/components/functionalities/passwordValidation.jsx
@@ -6,7 +6,7 @@ const PasswordValidator = ({ password }) => {
   const upperCase = /[A-Z]/.test(password);
   const lowerCase = /[a-z]/.test(password);
   const number = /[0-9]/.test(password);
-  const special=/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
+  const special=/[!@#$%^&*()_\-=\[\]{};':"\\|,+.<>\/?]/.test(password);
 
   const getClass = (condition) => {
     if (condition) return 'text-green-600';

--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -86,7 +86,7 @@ const Register = () => {
     const hasUpperCase = /[A-Z]/.test(password);
     const hasLowerCase = /[a-z]/.test(password);
     const hasNumber = /\d/.test(password);
-    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>_-]/.test(password); 
+    const hasSpecialChar = /[!@#$%^&+*(),.?":{}|<>_-]/.test(password); 
 
     console.log("validatePassword debug:", {
       password,


### PR DESCRIPTION
Fixed the bug on Register form, now the special char + is enable to use in a password

## Summary by Sourcery

Bug Fixes:
- Allow "+" character in the special-character check of password validation